### PR TITLE
OTServer: include missing header file

### DIFF
--- a/src/base/OTServer.cpp
+++ b/src/base/OTServer.cpp
@@ -172,8 +172,11 @@
 #include <map>
 #include <memory>
 #include <fstream>
-
 #include <time.h>
+
+#ifndef WIN32
+#include <unistd.h>
+#endif
 
 #define SERVER_CONFIG_KEY "server"
 #define SERVER_DATA_DIR "server_data"


### PR DESCRIPTION
Needed because I removed tinythread in OT: https://github.com/Open-Transactions/opentxs/pull/126
