### PR TITLE
gtest submodule url update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/gtest"]
 	path = deps/gtest
-	url = https://github.com/monetas/gtest.git
+	url = https://github.com/open-transactions/gtest.git


### PR DESCRIPTION
This updates the url for the gtest submodule to point to the Open-Transactions gtest project 